### PR TITLE
Register Haskell

### DIFF
--- a/Language.ml
+++ b/Language.ml
@@ -16,6 +16,7 @@ type t =
 | Elixir
 | Go
 | Hack
+| Haskell
 | Html
 | Java
 | Js
@@ -266,6 +267,19 @@ let list = [
   excluded_exts = [];
   reverse_exts = None;
   shebangs = [{|hhvm|}];
+  tags = [];
+};
+{
+  id = Haskell;
+  id_string = "haskell";
+  name = "Haskell";
+  keys = [{|haskell|}; {|hs|}];
+  exts = [{|.hs|}; {|.lhs|}];
+  maturity = Develop;
+  example_ext = Some {|.hs|};
+  excluded_exts = [];
+  reverse_exts = None;
+  shebangs = [{|runhaskell|}; {|runghc|}];
   tags = [];
 };
 {

--- a/Language.mli
+++ b/Language.mli
@@ -16,6 +16,7 @@ type t =
 | Elixir
 | Go
 | Hack
+| Haskell
 | Html
 | Java
 | Js

--- a/generate.py
+++ b/generate.py
@@ -335,6 +335,16 @@ not ambiguous is welcome here.
     ),
     Language(
         comment="",
+        id_="haskell",
+        name="Haskell",
+        keys=["haskell", "hs"],
+        exts=[".hs", ".lhs"],
+        example_ext=".hs",
+        maturity=Maturity.DEVELOP,
+        shebangs=["runhaskell", "runghc"]
+    ),
+    Language(
+        comment="",
         id_="html",
         name="HTML",
         keys=["html"],

--- a/lang.json
+++ b/lang.json
@@ -278,6 +278,28 @@
     "tags": []
   },
   {
+    "id": "haskell",
+    "name": "Haskell",
+    "keys": [
+      "haskell",
+      "hs"
+    ],
+    "maturity": "develop",
+    "exts": [
+      ".hs",
+      ".lhs"
+    ],
+    "example_ext": ".hs",
+    "excluded_exts": [],
+    "reverse_exts": null,
+    "shebangs": [
+      "runhaskell",
+      "runghc"
+    ],
+    "is_target_language": true,
+    "tags": []
+  },
+  {
     "id": "html",
     "name": "HTML",
     "keys": [


### PR DESCRIPTION
- [ ] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [ ] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data
	  generated by Semgrep 1.50.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
	  Note that the types related to the semgrep-core JSON output or the
	  semgrep-core RPC do not need to be backward compatible!
